### PR TITLE
feat(cli): parse command line arguments

### DIFF
--- a/lib/issues/cli.ex
+++ b/lib/issues/cli.ex
@@ -1,0 +1,49 @@
+defmodule Issues.CLI do
+
+  @moduledoc """
+  Handle the command line parsing and the dispatch to the various
+  functions that end up generating a table of the last _n_ issues
+  in a github project
+  """
+  @default_count 4
+
+  def run(argv) do
+    argv
+    |> parse_args
+    |> process
+  end
+
+  @doc """
+  `argv` can . be -h or --help, which returns :help.
+
+  Otherwise it is a github user name, project name, and (optionally)
+  the number of entries to format.
+
+  Return a tuple of `{user, project, count}`, or `:help` if help
+  was given.
+  """
+  def parse_args(argv) do
+    parse = OptionParser.parse(argv, switches: [help: :boolean],
+                                     aliases:  [h:    :help   ])
+    case parse do
+      {[help: true], _, _} -> :help
+      
+      {_, [user, project, count], _} -> {user, project, String.to_integer(count)}
+
+      {_, [user, project], _} -> {user, project, @default_count}
+
+      _ -> :help
+    end
+  end
+
+  def process(:help) do
+    IO.puts """
+    usage: issues <user> <project> [count | #{@default_count}]
+    """
+    System.halt(0)
+  end
+
+  def process({user, project, _count}) do
+    Issues.GithubIssues.fetch(user, project)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -28,6 +28,8 @@ defmodule Issues.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    []
+    [ 
+      {:httpoison, "~> 0.9"}
+    ]
   end
 end

--- a/test/cli_test.exs
+++ b/test/cli_test.exs
@@ -1,0 +1,20 @@
+defmodule CliTest do
+  use ExUnit.Case
+  doctest Issues
+
+  import Issues.CLI, only: [parse_args: 1]
+
+  test ":help returned by option parsing with -h and --help options" do 
+    assert parse_args(["-h",     "anything"]) == :help
+    assert parse_args(["--help", "anything"]) == :help
+  end
+
+  test "three values returned if three given" do
+    assert parse_args(["user", "project", "99"]) == {"user", "project", 99}
+  end
+  
+  test "count is defaulted if two values given" do
+    assert parse_args(["user", "project"]) == {"user", "project", 4}
+  end
+
+end


### PR DESCRIPTION
**What**

Handles parsing of command line arguments, separate from other modules, to interface between what the user types and what our program does

